### PR TITLE
Use python3 specifically and pick it out of the path

### DIFF
--- a/cxc-build
+++ b/cxc-build
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #SPDX-License-Identifier: BSD-3-Clause
 
 from os import path, mkdir


### PR DESCRIPTION
This fixes builds on macOS (and elsewhere i.e. Nix) that have python in unusual places or (annoyingly) default to python2 still.